### PR TITLE
Updates to Armenia

### DIFF
--- a/tax_microsim.py
+++ b/tax_microsim.py
@@ -85,6 +85,7 @@ class Application(tk.Frame):
 
         #Create Tab Control
         TAB_CONTROL = ttk.Notebook(master)
+        
 
         self.TAB1 = ttk.Frame(TAB_CONTROL)
         TAB_CONTROL.add(self.TAB1, text=' Start ')
@@ -507,6 +508,9 @@ class Application(tk.Frame):
 def main():
     ctypes.windll.shcore.SetProcessDpiAwareness(1)
     root = tk.Tk()
+    f = tkfont.Font(family='Courier New', size=12)
+    s = ttk.Style()
+    s.configure('.', font=f)
     root.geometry('1000x600')
     root.title("World Bank Microsimulation Model")
     root.state('zoomed')

--- a/taxcalc/current_law_policy_pit_armenia.json
+++ b/taxcalc/current_law_policy_pit_armenia.json
@@ -8,7 +8,7 @@
         "row_label": [  
             "2021"
         ],
-        "start_year": 2021,
+        "start_year": [2021, 2022, 2023],
         "cpi_inflatable": false,
         "cpi_inflated": false,
         "col_var": "",
@@ -16,7 +16,7 @@
         "boolean_value": false,
         "integer_value": false,
         "value": [
-            0.22
+            0.22, 0.21, 0.2
         ],
         "range": {
             "min": 0,
@@ -92,7 +92,7 @@
         "row_label": [  
             "2021"
         ],
-        "start_year": 2021,
+        "start_year": [2021, 2022, 2023],
         "cpi_inflatable": false,
         "cpi_inflated": false,
         "col_var": "",
@@ -100,7 +100,7 @@
         "boolean_value": false,
         "integer_value": false,
         "value": [
-            0.22
+            0.22, 0.21, 0.2
         ],
         "range": {
             "min": 0,
@@ -148,7 +148,7 @@
         "row_label": [  
             "2021"
         ],
-        "start_year": 2021,
+        "start_year": [2021, 2022, 2023],
         "cpi_inflatable": false,
         "cpi_inflated": false,
         "col_var": "",
@@ -156,7 +156,7 @@
         "boolean_value": false,
         "integer_value": false,
         "value": [
-            0.22
+            0.22, 0.21, 0.2
         ],
         "range": {
             "min": 0,
@@ -205,7 +205,7 @@
         "row_label": [
             "2021"
         ],
-        "start_year": 2021,
+        "start_year": [2021, 2022, 2023],
         "cpi_inflatable": false,
         "cpi_inflated": false,
         "col_var": "",
@@ -213,7 +213,7 @@
         "boolean_value": false,
         "integer_value": false,
         "value": [
-           0.22
+           0.22, 0.21, 0.2
         ],
         "range": {
             "min": 0,
@@ -658,7 +658,7 @@
         "row_label": [
     	"2021"
         ],
-        "start_year": 2021,
+        "start_year": [2021, 2022, 2023],
         "cpi_inflatable": true,
         "cpi_inflated": false,
         "col_var": "",
@@ -666,7 +666,7 @@
         "boolean_value": false,
         "integer_value": false,
         "value": [
-    	  68000
+    	  68000, 68000, 75000
         ],
         "range": {
     	"min": 0,
@@ -686,7 +686,7 @@
   		"row_label": [
   			"2021"
   		],
-  		"start_year": 2021,
+  		"start_year": [2021, 2022, 2023],
   		"cpi_inflatable": true,
   		"cpi_inflated": false,
   		"col_var": "",
@@ -694,7 +694,7 @@
   		"boolean_value": false,
   		"integer_value": false,
   		"value": [
-  			0.035
+  			0.035, 0.045, 0.05
   		],
   		"range": {
   			"min": 0,

--- a/taxcalc/functions_pit_armenia.py
+++ b/taxcalc/functions_pit_armenia.py
@@ -22,7 +22,7 @@ def cal_max_annual_income_lowssc(max_income_pm_low_ssc, max_annual_income_low_ss
 "Calculation of monthly cap for social payment - (15 times the minimum wage per pm)"
 @iterate_jit(nopython=True)
 def cal_max_annual_income_ssc(min_wage_pm, max_annual_income_ssc):
-   max_annual_income_ssc = (min_wage_pm*15)
+   max_annual_income_ssc = (min_wage_pm*15)*12
    return (max_annual_income_ssc)
 
 

--- a/taxcalc/tax_incentives_benchmark_pit_armenia.json
+++ b/taxcalc/tax_incentives_benchmark_pit_armenia.json
@@ -1,0 +1,8 @@
+
+
+{
+    "policy": {
+    "_mortgage_credit_ceiling": {"2021": [0.0]},
+   
+    }
+}


### PR DESCRIPTION
Updates to Armenia Model -
1. Rates were changed from 2021:22% to [2021, 2022, 2023]:[0.22, 0.21, 0.2]
2. Rates for SSC were also changed from 2021:0.035 to [2021, 2022, 2023]:[0.035, 0.045, 0.05]
3. Min wages were updated to 75000 AMD p.m. in 2023 onwards
4. In functions file, calculation of maximum annual wage for SSC was corrected by multiplying it by 12 (which was missing earlier) - now it becomes min wage*15*12